### PR TITLE
Consolidate include directives in Background.cpp

### DIFF
--- a/src/Background.cpp
+++ b/src/Background.cpp
@@ -1,7 +1,7 @@
 // Copyright © 2008-2024 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
-#include "Background.h"
+#include "Background.h" 
 
 #include "FileSystem.h"
 #include "FloatComparison.h"


### PR DESCRIPTION
Removed a newline character between #include "Background.h" and subsequent #include directives in Background.cpp to consolidate them into a single block.