### PR TITLE
Add equality tests for StringName class

### DIFF
--- a/src/test/TestStringName.cpp
+++ b/src/test/TestStringName.cpp
@@ -186,4 +186,14 @@ TEST_CASE("StringName")
 		StringTable::Get()->Reclaim(true);
 		CHECK(StringTable::Get()->Size() == 0);
 	}
+
+	SUBCASE("Equality")
+	{
+		StringName a("this is a test");
+		StringName b("this is a test");
+		StringName c("this is a test 2");
+		CHECK(a == b);
+		CHECK(a != c);
+		CHECK(b != c);
+	}
 }


### PR DESCRIPTION
Added a new subcase "Equality" to the TEST_CASE("StringName") in the `TestStringName.cpp` file.
The new subcase tests the equality and inequality operators for the `StringName` class.
Specifically, it creates three `StringName` objects (`a`, `b`, and `c`) and checks:
  * `a` is equal to `b`
  * `a` is not equal to `c`
  * `b` is not equal to `c`